### PR TITLE
Issue #3 - Write helpers.js whether it exists or not.

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -8,7 +8,7 @@
     "watch:js": "./node_modules/.bin/webpack --watch --config webpack.config.dev.js",
     "lint:js": "./node_modules/.bin/eslint -c .eslintrc.json ./src",
     "build:js": "yarn run build:js-helpers && BABEL_ENV=production ./node_modules/.bin/webpack --progress --display-reasons --display-modules --config webpack.config.js",
-    "build:js-helpers": "./node_modules/.bin/babel-external-helpers | ./node_modules/.bin/minify --mangle false >> dist/helpers.js"
+    "build:js-helpers": "./node_modules/.bin/babel-external-helpers | ./node_modules/.bin/minify --mangle false > dist/helpers.js"
   },
   "dependencies": {
     "prop-types": "^15.6.0",

--- a/js/package.json
+++ b/js/package.json
@@ -8,7 +8,7 @@
     "watch:js": "./node_modules/.bin/webpack --watch --config webpack.config.dev.js",
     "lint:js": "./node_modules/.bin/eslint -c .eslintrc.json ./src",
     "build:js": "yarn run build:js-helpers && BABEL_ENV=production ./node_modules/.bin/webpack --progress --display-reasons --display-modules --config webpack.config.js",
-    "build:js-helpers": "[ -e dist/helpers.js ] && rm dist/helpers.js && ./node_modules/.bin/babel-external-helpers | ./node_modules/.bin/minify --mangle false >> dist/helpers.js"
+    "build:js-helpers": "./node_modules/.bin/babel-external-helpers | ./node_modules/.bin/minify --mangle false >> dist/helpers.js"
   },
   "dependencies": {
     "prop-types": "^15.6.0",


### PR DESCRIPTION
Simplifies the `build:js-helpers` script. 